### PR TITLE
Use Kirby’s own uuid() function.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "getkirby/composer-installer": "^1.2",
     "illuminate/config": "^8.0",
     "illuminate/view": "^8.0",
-    "ramsey/uuid": "^4.2",
     "voku/html-min": "^4.4"
   },
   "require-dev": {

--- a/src/BladeFactory.php
+++ b/src/BladeFactory.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\View\Factory;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\View;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\Engines\CompilerEngine;
@@ -18,6 +19,11 @@ class BladeFactory
 {
     static public function register(array $pathsToTemplates, string $pathToCompiledTemplates)
     {
+        // Use Kirby’s internal uuid() helper function instead of
+        // ramsey/uuid to avoid installtion of several additional
+        // dependencies.
+        Str::createUuidsUsing('uuid');
+
         $container = App::getInstance();
 
         // we have to bind our app class to the interface

--- a/src/BladeFactory.php
+++ b/src/BladeFactory.php
@@ -20,7 +20,7 @@ class BladeFactory
     static public function register(array $pathsToTemplates, string $pathToCompiledTemplates)
     {
         // Use Kirby’s internal uuid() helper function instead of
-        // ramsey/uuid to avoid installtion of several additional
+        // ramsey/uuid to avoid installation of several additional
         // dependencies.
         Str::createUuidsUsing('uuid');
 


### PR DESCRIPTION
If no `uuid` generator has been set, the plugin will throw an error when using @once in a template.