### PR TITLE
Enable blade template for content representations

### DIFF
--- a/src/Template.php
+++ b/src/Template.php
@@ -100,7 +100,7 @@ class Template extends KirbyTemplate
     public function getFilename(string $name = null): string
     {
         if ($name) {
-            return $this->templatesPath . "/" . $name . "." . $this->extension();
+            return $this->templatesPath . "/" . $name . "." . ($this->isBlade() ? $this->bladeExtension() : $this->extension());
         }
 
         if ($this->isBlade()) {


### PR DESCRIPTION
Before, the template component only allowed plain PHP templates for content representations.