### PR TITLE
Get rid of html minify

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ The default values of the package are:
 | leitsch.blade.views          | site/cache/views | (string) | Location of the views cached |
 | leitsch.blade.directives     | [] | (array) | Array with the custom directives |
 | leitsch.blade.ifs            | [] | (array) | Array with the custom if statements |
-| leitsch.blade.minify.enabled | false | (boolean) | Enable/disable minify HTML output |
-| leitsch.blade.minify.options | [] | (array) | Minify supported options |
 
 All the values can be updated in the `config.php` file.
 
@@ -139,52 +137,6 @@ After declaration you can use it like:
     Please Log In
 @endlogged
 ```
-
-### Filters
-
-**Breaking Change: After the 1.6 version, the filters feature has been removed. Use 1.5.x to use filters.**
-
-### Minify
-
-**Setup**
-
-```php
-'leitsch.blade.minify.enabled' => true,
-'leitsch.blade.minify.options' => [
-    'doOptimizeViaHtmlDomParser' => true, // set true/false or remove line to default
-    'doRemoveSpacesBetweenTags'  => false // set true/false or remove line to default
-],
-```
-
-**Available Minify Options**
-
-| Option | Description |
-|:---|:---|
-| doOptimizeViaHtmlDomParser | optimize html via "HtmlDomParser()" |
-| doRemoveComments | remove default HTML comments (depends on "doOptimizeViaHtmlDomParser(true)") |
-| doSumUpWhitespace | sum-up extra whitespace from the Dom (depends on "doOptimizeViaHtmlDomParser(true)") |
-| doRemoveWhitespaceAroundTags | remove whitespace around tags (depends on "doOptimizeViaHtmlDomParser(true)") |
-| doOptimizeAttributes | optimize html attributes (depends on "doOptimizeViaHtmlDomParser(true)") |
-| doRemoveHttpPrefixFromAttributes | remove optional "http:"-prefix from attributes (depends on "doOptimizeAttributes(true)") |
-| doRemoveHttpsPrefixFromAttributes | remove optional "https:"-prefix from attributes (depends on "doOptimizeAttributes(true)") |
-| doKeepHttpAndHttpsPrefixOnExternalAttributes | keep "http:"- and "https:"-prefix for all external links |
-| doMakeSameDomainsLinksRelative | make some links relative, by removing the domain from attributes |
-| doRemoveDefaultAttributes | remove defaults (depends on "doOptimizeAttributes(true)" | disabled by default) |
-| doRemoveDeprecatedAnchorName | remove deprecated anchor-jump (depends on "doOptimizeAttributes(true)") |
-| doRemoveDeprecatedScriptCharsetAttribute | remove deprecated charset-attribute - the browser will use the charset from the HTTP-Header, anyway (depends on "doOptimizeAttributes(true)") |
-| doRemoveDeprecatedTypeFromScriptTag | remove deprecated script-mime-types (depends on "doOptimizeAttributes(true)") |
-| doRemoveDeprecatedTypeFromStylesheetLink | remove "type=text/css" for css links (depends on "doOptimizeAttributes(true)") |
-| doRemoveDeprecatedTypeFromStyleAndLinkTag | remove "type=text/css" from all links and styles |
-| doRemoveDefaultMediaTypeFromStyleAndLinkTag | remove "media="all" from all links and styles |
-| doRemoveDefaultTypeFromButton | remove type="submit" from button tags |
-| doRemoveEmptyAttributes | remove some empty attributes (depends on "doOptimizeAttributes(true)") |
-| doRemoveValueFromEmptyInput | remove 'value=""' from empty `<input>` (depends on "doOptimizeAttributes(true)") |
-| doSortCssClassNames | sort css-class-names, for better gzip results (depends on "doOptimizeAttributes(true)") |
-| doSortHtmlAttributes | sort html-attributes, for better gzip results (depends on "doOptimizeAttributes(true)") |
-| doRemoveSpacesBetweenTags | remove more (aggressive) spaces in the dom (disabled by default) |
-| doRemoveOmittedQuotes | remove quotes e.g. class="lall" => class=lall |
-| doRemoveOmittedHtmlTags | remove ommitted html tags e.g. \<p\>lall\<\/p\> => \<p\>lall |
-You can get detailed information from `HtmlMin` library: [voku/HtmlMin](https://github.com/voku/HtmlMin#options)
 
 ## Credits
 - [Kirby Blade](https://github.com/afbora/kirby-blade) by [@afbora](https://github.com/afbora)

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
     "php": "^8.0",
     "getkirby/composer-installer": "^1.2",
     "illuminate/config": "^9.0",
-    "illuminate/view": "^9.0",
-    "voku/html-min": "^4.4"
+    "illuminate/view": "^9.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.5"

--- a/index.php
+++ b/index.php
@@ -16,10 +16,6 @@ Kirby::plugin('leitsch/blade', [
         },
         'directives' => [],
         'ifs' => [],
-        'minify' => [
-            'enabled' => false,
-            'options' => [],
-        ]
     ],
     'components' => [
         'template' => function (Kirby $kirby, string $name, string $contentType = null) {

--- a/src/BladeDirectives.php
+++ b/src/BladeDirectives.php
@@ -6,7 +6,8 @@ use Illuminate\Support\Facades\Blade;
 
 class BladeDirectives
 {
-    public static function register() {
+    public static function register()
+    {
         Blade::directive('asset', function (string $path) {
             return "<?php echo asset($path) ?>";
         });

--- a/src/BladeFactory.php
+++ b/src/BladeFactory.php
@@ -8,8 +8,8 @@ use Illuminate\Contracts\View\Factory;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\View;
+use Illuminate\Support\Str;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\DynamicComponent;
 use Illuminate\View\Engines\CompilerEngine;
@@ -18,7 +18,7 @@ use Illuminate\View\FileViewFinder;
 
 class BladeFactory
 {
-    static public function register(array $pathsToTemplates, string $pathToCompiledTemplates)
+    public static function register(array $pathsToTemplates, string $pathToCompiledTemplates)
     {
         $container = App::getInstance();
 

--- a/src/Template.php
+++ b/src/Template.php
@@ -35,25 +35,10 @@ class Template extends KirbyTemplate
             View::share('pages', $data['pages']);
             View::share('page', $data['page']);
 
-            $html = View::file($this->file(), $data)->render();
-        } else {
-            $html = Tpl::load($this->file(), $data);
+            return View::file($this->file(), $data)->render();
         }
 
-        if (option('leitsch.blade.minify.enabled', false) === true) {
-            $htmlMin = new HtmlMin();
-            $options = option('leitsch.blade.minify.options', []);
-
-            foreach ($options as $option => $status) {
-                if (method_exists($htmlMin, $option)) {
-                    $htmlMin->{$option}((bool)$status);
-                }
-            }
-
-            return $htmlMin->minify($html);
-        }
-
-        return $html;
+        return Tpl::load($this->file(), $data);
     }
 
     public function isBlade(): bool
@@ -66,9 +51,9 @@ class Template extends KirbyTemplate
         if (! is_null($this->extension)) {
             return $this->extension;
         }
-        
+
         $bladeRoot = $this->templatesPath . "/" . $this->name() . "." . static::EXTENSION_BLADE;
-        
+
         return $this->extension = file_exists($bladeRoot)
             ? static::EXTENSION_BLADE
             : static::EXTENSION_FALLBACK;

--- a/src/Template.php
+++ b/src/Template.php
@@ -8,7 +8,6 @@ use Kirby\Cms\App;
 use Kirby\Cms\Template as KirbyTemplate;
 use Kirby\Filesystem\F;
 use Kirby\Toolkit\Tpl;
-use voku\helper\HtmlMin;
 
 class Template extends KirbyTemplate
 {
@@ -97,6 +96,7 @@ class Template extends KirbyTemplate
     public function getFilename(?string $name = null): string
     {
         $name = $name ?? $this->name();
+
         return "{$this->templatesPath}/{$name}.{$this->extension()}";
     }
 }


### PR DESCRIPTION
The configuration of HTML minify was too overwhelming. We get rid of it for the moment.