### PR TITLE
Feature/components registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,68 @@ After declaration you can use it like:
 @endlogged
 ```
 
+### Components
+
+Laravel allows the usage of custom [components](https://laravel.com/docs/9.x/blade#components) with a Vue-like syntax. You can register your components by adding them to the `site/components` directory. E.g. you want to have define a `<x-language-toggle active="de" />` component, you can either use an anonymous component, which contains all the code and goes to your templates directory:
+
+```blade
+# site/templates/components/language-toggle.blade.php
+
+@props([
+    'active',
+])
+
+<div>[…]</div>
+```
+
+For more extensive components, you might want to use a class instead. The easiest way would be to store the component model in `site/components`, very much like a [page model](https://getkirby.com/docs/guide/templates/page-models) in Kirby works:
+
+```php
+# site/components/language-toggle.php
+
+<?php
+
+class LanguageToggleComponent extends BladeComponent {
+    // ...
+}
+```
+
+Nested component (`<x-language-toggle.option />`):
+
+```php
+# site/components/language-toggle/option.php
+
+<?php
+
+class LanguageToggle_OptionComponent extends BladeComponent {
+    // ...
+}
+```
+
+
+You can also register components from other plugins. This allows you to define the models in custom namespaces and the usage of abitrary class names:
+
+```php
+#site/plugins/my-plugin/index.php
+
+<?php
+
+use My\Plugin\BladeComponents\LanguageToggle;
+
+Kirby::plugin('my/plugin', [
+    'bladeComponents' => [
+        'language-toggle' => LanguageToggle::class,
+    ],
+]);
+
+```
+
+If you want to use any component outside of a regular template, you can use the `component($name, $props = [], $attributes = [])` helper function:
+
+```php
+echo component('language-toggle', ['active' => 'de']);
+```
+
 ### Hook
 
 For use cases such as HTML minification, there's a custom hook for manipulating rendered HTML output:

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ You can also register components from other plugins. This allows you to define t
 use My\Plugin\BladeComponents\LanguageToggle;
 
 Kirby::plugin('my/plugin', [
-    'bladeComponents' => [
+    'blade.components' => [
         'language-toggle' => LanguageToggle::class,
     ],
 ]);

--- a/helpers.php
+++ b/helpers.php
@@ -34,3 +34,9 @@ if (! function_exists('component')) {
         return View::make("components.{$name}", $props);
     }
 }
+
+if (! function_exists('view_make')) {
+    function make_view(string $view, array $data = [], array $mergeData = []) {
+        return View::make($view, $data, $mergeData);
+    }
+}

--- a/index.php
+++ b/index.php
@@ -1,16 +1,19 @@
 <?php
 
 use Kirby\Cms\App as Kirby;
+use Kirby\Cms\App;
+use Kirby\Filesystem\Dir;
 use Kirby\Filesystem\F;
+use Kirby\Toolkit\Str;
 use Leitsch\Blade\BladeDirectives;
 use Leitsch\Blade\BladeFactory;
 use Leitsch\Blade\BladeIfStatements;
+use Leitsch\Blade\Helpers;
 use Leitsch\Blade\Paths;
 use Leitsch\Blade\Snippet;
 use Leitsch\Blade\Template;
 
 @include_once __DIR__ . '/vendor/autoload.php';
-
 
 /**
  * Don’t use class_alias here, because that would break autocomplete
@@ -42,19 +45,45 @@ Kirby::plugin('leitsch/blade', [
 
             $componentModels = [];
 
-            foreach (glob($this->root('site') . '/components/*.php') as $model) {
-                $name  = F::name($model);
-                $class = str_replace(['.', '-', '_'], '', $name) . 'Component';
-    
-                // load the model class
-                F::loadOnce($model);
+            // load components from `site/components` directory (basically works
+            // like page models)
+            // site/components/demo.php => \DemoComponent
+            // site/components/demo/sub.php => \Demo_SubComponent
+            // site/components/demo/sub/sub.php => \Demo_Sub_SubComponent
+            $path = $this->root('site') . '/components';
 
-                if (class_exists($class) === true) {
+            foreach (Dir::index($path, true) as $model) {
+                if (pathinfo($model, PATHINFO_EXTENSION) !== 'php') {
+                    continue;
+                }
+
+                $parts = ltrim(Str::after($model, $path), '/');
+                $parts = explode('/', $parts);
+                $last = count($parts) - 1;
+                $parts[$last] = F::name($parts[$last]);
+
+                $class = implode('_', array_map(fn($item) => str_replace(['.', '-', '_'], '', $item), $parts)) . 'Component';
+                $name = implode('.', $parts);
+
+                // load the model class
+                F::loadOnce($path . '/' . $model);
+
+                if (class_exists($class)) {
+                    // ensure to register a fully-qualifield classname including
+                    // namespace, so it works in any namespace
                     $r = new ReflectionClass($class);
                     $componentModels[$r->getNamespaceName() . '\\' . $r->getName()] = $name;
                 }
             }
-            
+
+            // get components that have been registred by other plugins
+            foreach (App::instance()->plugins() as $plugin) {
+                $componentModels = array_merge(
+                    $componentModels,
+                    array_flip($plugin->extends()['bladeComponents'] ?? []),
+                );
+            }
+
             BladeFactory::register(
                 [Paths::getPathTemplates()],
                 Paths::getPathViews(),

--- a/index.php
+++ b/index.php
@@ -1,15 +1,10 @@
 <?php
 
 use Kirby\Cms\App as Kirby;
-use Kirby\Cms\App;
-use Kirby\Filesystem\Dir;
-use Kirby\Filesystem\F;
 use Kirby\Toolkit\A;
-use Kirby\Toolkit\Str;
 use Leitsch\Blade\BladeDirectives;
 use Leitsch\Blade\BladeFactory;
 use Leitsch\Blade\BladeIfStatements;
-use Leitsch\Blade\Helpers;
 use Leitsch\Blade\Paths;
 use Leitsch\Blade\Snippet;
 use Leitsch\Blade\Template;
@@ -39,7 +34,7 @@ Kirby::plugin('leitsch/blade', [
             $templatePaths = [];
 
             // stuff from other plugins
-            foreach (App::instance()->plugins() as $plugin) {
+            foreach (kirby()->plugins() as $plugin) {
                 $extends = $plugin->extends();
                 $componentModels = array_merge($componentModels, array_flip(A::get($extends, 'blade.components', [])));
                 $componentNamespaces = array_merge($componentNamespaces, A::get($extends, 'blade.namespaces', []));

--- a/src/BladeFactory.php
+++ b/src/BladeFactory.php
@@ -21,7 +21,8 @@ class BladeFactory
     public static function register(
         array $pathsToTemplates,
         string $pathToCompiledTemplates,
-        array $components
+        array $components,
+        array $namespaces
     ) {
         $container = App::getInstance();
 
@@ -90,6 +91,10 @@ class BladeFactory
 
         foreach ($components as $name => $class) {
             $bladeCompiler->component($name, $class);
+        }
+
+        foreach ($namespaces as $prefix => $namespace) {
+            $bladeCompiler->componentNamespace($namespace, $prefix);
         }
 
         // Use Kirby’s internal uuid() helper function instead of

--- a/src/BladeFactory.php
+++ b/src/BladeFactory.php
@@ -39,7 +39,25 @@ class BladeFactory
 
         $viewResolver->register('blade', fn () => new CompilerEngine($bladeCompiler));
 
-        $viewFinder = new FileViewFinder($filesystem, $pathsToTemplates);
+        $viewFinder = new class($filesystem, $pathsToTemplates) extends FileViewFinder {
+            // public function find($name) {
+            //     die("findo: $name :");
+
+            //     if (isset($this->views[$name])) {
+            //         return $this->views[$name];
+            //     }
+
+            //     $class = str_replace(['.', '-', '_'], '', $name) . 'Component';
+
+            //     if (class_exists($class)) {
+            //         return $this->views[$name] = $class;
+            //     }
+
+            //     die("❌ no co | {$class} | {$name}");
+
+            //     return parent::find($name);
+            // }
+        };
         $viewFactory = new \Illuminate\View\Factory($viewResolver, $viewFinder, $eventDispatcher);
         $viewFactory->setContainer($container);
         Facade::setFacadeApplication($container);
@@ -73,7 +91,6 @@ class BladeFactory
         foreach ($components as $name => $class) {
             $bladeCompiler->component($name, $class);
         }
-        // exit;
 
         // Use Kirby’s internal uuid() helper function instead of
         // ramsey/uuid to avoid installation of several additional

--- a/src/BladeFactory.php
+++ b/src/BladeFactory.php
@@ -69,7 +69,7 @@ class BladeFactory
         $container['config'] = $config;
 
         $bladeCompiler->component(DynamicComponent::class, 'dynamic-component');
-        
+
         foreach ($components as $name => $class) {
             $bladeCompiler->component($name, $class);
         }

--- a/src/BladeFactory.php
+++ b/src/BladeFactory.php
@@ -39,7 +39,7 @@ class BladeFactory
 
         $viewResolver->register('blade', fn () => new CompilerEngine($bladeCompiler));
 
-        $viewFinder = new class($filesystem, $pathsToTemplates) extends FileViewFinder {
+        $viewFinder = new class ($filesystem, $pathsToTemplates) extends FileViewFinder {
             // public function find($name) {
             //     die("findo: $name :");
 

--- a/src/BladeFactory.php
+++ b/src/BladeFactory.php
@@ -18,8 +18,11 @@ use Illuminate\View\FileViewFinder;
 
 class BladeFactory
 {
-    public static function register(array $pathsToTemplates, string $pathToCompiledTemplates)
-    {
+    public static function register(
+        array $pathsToTemplates,
+        string $pathToCompiledTemplates,
+        array $components
+    ) {
         $container = App::getInstance();
 
         // we have to bind our app class to the interface
@@ -65,7 +68,12 @@ class BladeFactory
         $config->set('view.compiled', $pathToCompiledTemplates);
         $container['config'] = $config;
 
-        $bladeCompiler->component('dynamic-component', DynamicComponent::class);
+        $bladeCompiler->component(DynamicComponent::class, 'dynamic-component');
+        
+        foreach ($components as $name => $class) {
+            $bladeCompiler->component($name, $class);
+        }
+        // exit;
 
         // Use Kirby’s internal uuid() helper function instead of
         // ramsey/uuid to avoid installation of several additional


### PR DESCRIPTION
This PR allows component classes to be registred in global namespace just by adding them to the `site/components` folder, just like page models work in Kirby.

- [x] Allow plugins to register components dynamically
- [ ] Allow views for components to be registered by plugins. For this, we probably need to extend the `FileViewFinder` class.
- [ ] Discuss `site/components` registry and naming scheme
- [ ] Discuss plugin registry
- [ ] Ensure ease-of-use of the whole registry stuff
- [ ] Consider adding support for namespaced components or use that ad plugin registry instead, see: https://laravel.com/docs/9.x/blade#manually-registering-components