### PR TITLE
Allow closure as option for template path

### DIFF
--- a/src/Paths.php
+++ b/src/Paths.php
@@ -8,7 +8,7 @@ class Paths
     {
         $optionPath = option('leitsch.blade.templates');
 
-        if ($optionPath !== null && is_dir($optionPath)) {
+        if ($optionPath !== null) {
             if (is_callable($optionPath)) {
                 return $optionPath();
             }

--- a/src/Paths.php
+++ b/src/Paths.php
@@ -6,19 +6,17 @@ class Paths
 {
     public static function getPathTemplates(): string
     {
-        $optionPath = option('leitsch.blade.templates');
+        $path = option('leitsch.blade.templates');
 
-        if ($optionPath !== null) {
-            if (is_callable($optionPath)) {
-                return $optionPath();
-            }
-
-            $path = kirby()->roots()->index() . "/" . $optionPath;
-        } else {
-            $path = kirby()->root('templates');
+        if (is_callable($path)) {
+            return $path();
         }
 
-        return $path;
+        if ($path !== null) {
+            return kirby()->roots()->index() . '/' . $path;
+        }
+
+        return kirby()->root('templates');
     }
 
     public static function getPathViews(): string


### PR DESCRIPTION
Currently  passing a function as option value for `leitsch.blade.templates` will throw an Exception on Line 11. Also Line 13 is probably unreachable since `$optionPath` can not be a valid directory and function at once. 

https://github.com/lukasleitsch/kirby-blade/blob/bda308a3b812383751e44446b94c37d28825ff1c/src/Paths.php#L11-L16

`is_dir()` expects a string as parameter and will throw an Exception when `$optionPath` is a function.

Was the intention of is_dir to validate that the function returns a valid path? For now just removed the is_dir check. 
